### PR TITLE
Change Slack etiquette section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Project communication occurs primarily and intentionally via our project [Slack]
 
 However, before you ask in Slack "what can I contribute to", be sure to keep reading this document for the answer to your question. :-)
 
-Also, please avoid use of the `@here` command in Slack, as you will be sending a notification to nearly 600 people. Just post your question and someone will respond soon.
+Also, please avoid use of the `@everyone` and `@channel` commands in Slack, as you will be sending a notification to nearly 600 people. Just post your question and someone will respond soon.
 
 ## Help Wanted
 


### PR DESCRIPTION
I think that `@here` isn't as bad as `@everyone` or `@channel` since `@here` only notifies people currently active on the Slack as per https://get.slack.help/hc/en-us/articles/202009646-Make-an-announcement

cc @HospitalRun/core-maintainers
